### PR TITLE
Add template for Google API Keys not on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Secret Keys
+secret_key/google_keys.py

--- a/oh_queue/__init__.py
+++ b/oh_queue/__init__.py
@@ -11,13 +11,15 @@ from oh_queue import assets, auth
 from oh_queue.models import db, TicketStatus
 from raven.contrib.flask import Sentry
 
+# Get the Google API Keys
+from secret_key import google_keys
+
 # Initialize the application
 app = Flask(__name__)
 app.config.from_object('config')
 
-#TODO: Change to HKN account
-app.config["GOOGLE_ID"] = "80342984984-6lvqn134m1uevuqbnaop6jhlb6qcotiv.apps.googleusercontent.com"
-app.config["GOOGLE_SECRET"] = "CQNyFBWBV7y7eEq_qgSlsJk2"
+app.config["GOOGLE_ID"] = google_keys.GOOGLE_ID
+app.config["GOOGLE_SECRET"] = google_keys.GOOGLE_SECRET
 
 
 

--- a/secret_key/google_keys.py.in
+++ b/secret_key/google_keys.py.in
@@ -1,0 +1,24 @@
+# Python template to insert in your Google Keys
+
+"""
+Settings used during registration:
+ - Project settings must be "External" to allow for berkeley.edu emails
+    - "Internal" only allows hkn.eecs.berkeley.edu emails to pass through
+ - Authorized redirect URIs:
+    - https://hkn-tutoring.eecs.berkeley.edu/login/authorized
+    - http://localhost:5000/login/authorized
+    - http://127.0.0.1:5000/login/authorized
+ - Support Email + Developer contact information:
+    - OPS email is used
+ - App domain:
+    - Application home page: http://hkn-tutoring.eecs.berkeley.edu
+    - Application private policy link:
+        https://security.berkeley.edu/policy/privacy-statement-uc-berkeley-websites
+ - Authorized Domains:
+    - berkeley.edu
+
+Get credentials at: https://console.cloud.google.com/apis/credentials
+"""
+
+GOOGLE_ID = "Client ID under your Credentials in your Google Cloud Console"
+GOOGLE_SECRET = "Client secret under your Credentials in your Google Cloud Console"


### PR DESCRIPTION
There was an incident where Google suddenly not allowed our hkn-tutoring queue to not allow login, and needed verification
However, the original author has graduated and as a result, the maintenance has passed down to CompServ and Tutoring

In the spirit of good practice of avoiding keys on the public web, the current Pull Request is a framework to allow for Secret Keys in a folder and then place that key on the server
This way it is not public to the world in this public GitHub repo

The plan is to place the Python file with the keys on the OCF Server under the `secret_key` folder (with only a template provided for those who fork from our repo)